### PR TITLE
Make xrdp services stop/restart gracefully

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 start_xrdp_services() {
     # Preventing xrdp startup failure
@@ -18,50 +18,7 @@ stop_xrdp_services() {
     exit 0
 }
 
-echo Entryponit script is Running...
-echo
-
-users=$(($#/3))
-mod=$(($# % 3))
-
-echo "users is $users"
-echo "mod is $mod"
-
-if [[ $# -eq 0 ]]; then
-    echo "No input parameters. exiting..."
-    echo "there should be 3 input parameters per user"
-    exit
-fi
-
-if [[ $mod -ne 0 ]]; then
-    echo "incorrect input. exiting..."
-    echo "there should be 3 input parameters per user"
-    exit
-fi
-echo "You entered $users users"
-
-while [ $# -ne 0 ]; do
-
-    #echo "username is $1"
-    useradd $1
-    wait
-    #getent passwd | grep foo
-    echo $1:$2 | chpasswd
-    wait
-    #echo "sudo is $3"
-    if [[ $3 == "yes" ]]; then
-        usermod -aG wheel $1
-    fi
-    wait
-    echo "user '$1' is added"
-
-    # Shift all the parameters down by three
-    shift 3
-done
-
-echo -e "This script is ended\n"
-
-echo -e "starting xrdp services...\n"
+echo -e "Starting xrdp services...\n"
 
 trap "stop_xrdp_services" SIGKILL SIGTERM SIGHUP SIGINT EXIT
 start_xrdp_services

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+
+start_xrdp_services() {
+    # Preventing xrdp startup failure
+    rm -rf /var/run/xrdp-sesman.pid
+    rm -rf /var/run/xrdp.pid
+    rm -rf /var/run/xrdp/xrdp-sesman.pid
+    rm -rf /var/run/xrdp/xrdp.pid
+
+    # Use exec ... to forward SIGNAL to child processes
+    xrdp-sesman
+    exec xrdp -n
+}
+
+stop_xrdp_services() {
+    xrdp --kill
+    xrdp-sesman --kill
+    exit 0
+}
+
 echo Entryponit script is Running...
 echo
 
@@ -8,13 +27,13 @@ mod=$(($# % 3))
 echo "users is $users"
 echo "mod is $mod"
 
-if [[ $# -eq 0 ]]; then 
+if [[ $# -eq 0 ]]; then
     echo "No input parameters. exiting..."
     echo "there should be 3 input parameters per user"
     exit
 fi
 
-if [[ $mod -ne 0 ]]; then 
+if [[ $mod -ne 0 ]]; then
     echo "incorrect input. exiting..."
     echo "there should be 3 input parameters per user"
     exit
@@ -27,7 +46,7 @@ while [ $# -ne 0 ]; do
     useradd $1
     wait
     #getent passwd | grep foo
-    echo $1:$2 | chpasswd 
+    echo $1:$2 | chpasswd
     wait
     #echo "sudo is $3"
     if [[ $3 == "yes" ]]; then
@@ -43,7 +62,6 @@ done
 echo -e "This script is ended\n"
 
 echo -e "starting xrdp services...\n"
-xrdp-sesman && xrdp -n 
 
-
-
+trap "stop_xrdp_services" SIGKILL SIGTERM SIGHUP SIGINT EXIT
+start_xrdp_services


### PR DESCRIPTION
Stop: SIGNAL is forwarded to xrdp process, so 'docker stop ...' works.
Restart: Existence of .pid prevents xrdp starts, so .pid will be removed.