### PR TITLE
added argument for additional packages

### DIFF
--- a/ubuntu-xfce/Dockerfile
+++ b/ubuntu-xfce/Dockerfile
@@ -1,6 +1,8 @@
 # https://github.com/danchitnis/container-xrdp
 
 FROM ubuntu:latest
+ARG ADDITIONAL_PACKAGES=""
+ENV ADDITIONAL_PACKAGES=${ADDITIONAL_PACKAGES}
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,7 +17,9 @@ RUN apt-get install -y \
     xfce4-screenshooter \
     xfce4-taskmanager \
     xfce4-terminal \
-    xfce4-xkb-plugin 
+    xfce4-xkb-plugin \
+    $ADDITIONAL_PACKAGES
+
 
 RUN apt-get install -y \
     sudo \


### PR DESCRIPTION
The xrdp image from [danielguerra69](https://github.com/danielguerra69/ubuntu-xrdp) has a build argument for additional packages, which is quite handy. Would you mind adding it in the Dockerfile?


